### PR TITLE
fix the alert rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+release-police.iml

--- a/main.rb
+++ b/main.rb
@@ -26,7 +26,7 @@ def check_repo(github, pagerduty, repo, warn_time)
   if master_last > develop_last
     time_since_merge = ((develop_last - master_last) / 60).to_i
     puts "#{repo} ok, was released after #{time_since_merge.abs} minutes"
-    incident = pagerduty.get_incident(develop['commit']['sha'])
+    incident = pagerduty.get_incident("release-police-#{repo}")
     incident.resolve unless incident.nil?
     return
   end
@@ -36,7 +36,7 @@ def check_repo(github, pagerduty, repo, warn_time)
 
   if time_since_merge > warn_time
     puts "#{repo} bad! code is #{time_since_merge} minutes old and not released."
-    pagerduty.trigger("#{repo} has unreleased commits for #{time_since_merge} mintues.", incident_key: develop['commit']['sha'])
+    pagerduty.trigger("#{repo} has unreleased commits for #{time_since_merge} mintues.", incident_key: "release-police-#{repo}")
   end
 end
 

--- a/main.rb
+++ b/main.rb
@@ -23,7 +23,10 @@ def check_repo(github, pagerduty, repo, warn_time)
   master_last = get_last(master)
   develop_last = get_last(develop)
 
-  time_since_merge = ((develop_last - master_last) / 60).to_i
+  return if master_last > develop_last
+
+  # Time since last merged to develop
+  time_since_merge = ((Time.now - develop_last) / 60).to_i
 
   if time_since_merge > warn_time
     puts "#{repo} bad! code is #{time_since_merge} minutes old and not released."

--- a/main.rb
+++ b/main.rb
@@ -23,7 +23,13 @@ def check_repo(github, pagerduty, repo, warn_time)
   master_last = get_last(master)
   develop_last = get_last(develop)
 
-  return if master_last > develop_last
+  if master_last > develop_last
+    time_since_merge = ((develop_last - master_last) / 60).to_i
+    puts "#{repo} ok, was released after #{time_since_merge.abs} minutes"
+    incident = pagerduty.get_incident(develop['commit']['sha'])
+    incident.resolve unless incident.nil?
+    return
+  end
 
   # Time since last merged to develop
   time_since_merge = ((Time.now - develop_last) / 60).to_i
@@ -31,8 +37,6 @@ def check_repo(github, pagerduty, repo, warn_time)
   if time_since_merge > warn_time
     puts "#{repo} bad! code is #{time_since_merge} minutes old and not released."
     pagerduty.trigger("#{repo} has unreleased commits for #{time_since_merge} mintues.", incident_key: develop['commit']['sha'])
-  else
-    puts "#{repo} ok, was released after #{time_since_merge.abs} minutes"
   end
 end
 


### PR DESCRIPTION
It was checking the time between commits to develop, leading into the condition where if one commits to develop way after a commit to master, and insta alert will trigger. This fixes it.
@rainforestapp/core @ukd1 